### PR TITLE
[refactor] 채팅 최적화

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -59,6 +59,9 @@ dependencies {
     annotationProcessor "jakarta.annotation:jakarta.annotation-api"
     annotationProcessor "jakarta.persistence:jakarta.persistence-api"
 
+    //redis
+    implementation 'org.springframework.boot:spring-boot-starter-data-redis'
+
 }
 
 tasks.named('test') {

--- a/src/main/java/com/capstone/ai_painter_backen/config/RedisConfig.java
+++ b/src/main/java/com/capstone/ai_painter_backen/config/RedisConfig.java
@@ -1,0 +1,55 @@
+package com.capstone.ai_painter_backen.config;
+
+import com.capstone.ai_painter_backen.dto.Message.MessageDto;
+import com.capstone.ai_painter_backen.service.redis.ExpirationListener;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.cache.annotation.EnableCaching;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+import org.springframework.data.redis.connection.RedisConnectionFactory;
+import org.springframework.data.redis.connection.lettuce.LettuceConnectionFactory;
+import org.springframework.data.redis.core.RedisTemplate;
+import org.springframework.data.redis.listener.PatternTopic;
+import org.springframework.data.redis.listener.RedisMessageListenerContainer;
+import org.springframework.data.redis.serializer.GenericJackson2JsonRedisSerializer;
+import org.springframework.data.redis.serializer.StringRedisSerializer;
+import java.util.LinkedList;
+
+@EnableCaching
+@Configuration
+@Slf4j
+public class RedisConfig {
+
+    @Value("${spring.redis.host}")
+    private String host;
+
+    @Value("${spring.redis.port}")
+    private int port;
+
+    private final String PATTERN = "__keyevent@*__:expired";
+
+    @Bean
+    public RedisConnectionFactory redisConnectionFactory() {
+        return new LettuceConnectionFactory(host, port);
+    }
+
+    @Bean
+    public RedisTemplate<String, LinkedList<MessageDto.MessageCacheDto>> redisTemplate(RedisConnectionFactory redisConnectionFactory) {
+        GenericJackson2JsonRedisSerializer genericJackson2JsonRedisSerializer = new GenericJackson2JsonRedisSerializer();
+        RedisTemplate<String, LinkedList<MessageDto.MessageCacheDto>> redisTemplate = new RedisTemplate<>();
+        redisTemplate.setConnectionFactory(redisConnectionFactory);
+        redisTemplate.setKeySerializer(new StringRedisSerializer());
+        redisTemplate.setValueSerializer(genericJackson2JsonRedisSerializer);
+        return redisTemplate;
+    }
+
+    @Bean
+    public RedisMessageListenerContainer redisMessageListenerContainer(RedisConnectionFactory redisConnectionFactory, ExpirationListener expirationListener) {
+        RedisMessageListenerContainer redisMessageListenerContainer = new RedisMessageListenerContainer();
+        redisMessageListenerContainer.setConnectionFactory(redisConnectionFactory);
+        redisMessageListenerContainer.addMessageListener(expirationListener, new PatternTopic(PATTERN));
+        redisMessageListenerContainer.setErrorHandler(e -> log.error("There was an error in redis key expiration listener container", e));
+        return redisMessageListenerContainer;
+    }
+}

--- a/src/main/java/com/capstone/ai_painter_backen/config/WebSocketConfig.java
+++ b/src/main/java/com/capstone/ai_painter_backen/config/WebSocketConfig.java
@@ -14,7 +14,7 @@ import org.springframework.web.socket.config.annotation.WebSocketMessageBrokerCo
 @RequiredArgsConstructor
 public class WebSocketConfig implements WebSocketMessageBrokerConfigurer {
 
-    //private final ChatPreHandler chatPreHandler;
+//    private final StompHandler stompHandler;
 
     @Override
     public void registerStompEndpoints(StompEndpointRegistry registry) {
@@ -30,11 +30,8 @@ public class WebSocketConfig implements WebSocketMessageBrokerConfigurer {
         registry.enableSimpleBroker("/sub");
     }
 
-    /* interceptor 에서 처리 (Filter 넘기고)
-    @Override
-    public void configureClientInboundChannel(ChannelRegistration registration) {
-        registration.interceptors(chatPreHandler);
-    }
-    */
-
+//    @Override
+//    public void configureClientInboundChannel(ChannelRegistration registration) {
+//        registration.interceptors(stompHandler);
+//    }
 }

--- a/src/main/java/com/capstone/ai_painter_backen/controller/Message/MessageController.java
+++ b/src/main/java/com/capstone/ai_painter_backen/controller/Message/MessageController.java
@@ -1,10 +1,6 @@
 package com.capstone.ai_painter_backen.controller.Message;
 
 import com.capstone.ai_painter_backen.dto.Message.MessageDto;
-import com.capstone.ai_painter_backen.dto.Message.MessageDto.MessageDeleteDto;
-import com.capstone.ai_painter_backen.dto.Message.MessageDto.MessagePostDto;
-import com.capstone.ai_painter_backen.dto.Result;
-import com.capstone.ai_painter_backen.dto.image.AfterImageDto;
 import com.capstone.ai_painter_backen.service.Message.MessageService;
 import io.swagger.v3.oas.annotations.Operation;
 import io.swagger.v3.oas.annotations.media.Content;
@@ -13,16 +9,12 @@ import io.swagger.v3.oas.annotations.responses.ApiResponse;
 import io.swagger.v3.oas.annotations.responses.ApiResponses;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
-import org.springframework.data.domain.Page;
 import org.springframework.data.domain.PageRequest;
 import org.springframework.data.domain.Pageable;
 import org.springframework.data.domain.Sort;
-import org.springframework.data.web.PageableDefault;
-import org.springframework.http.ResponseEntity;
 import org.springframework.messaging.handler.annotation.MessageMapping;
-import org.springframework.messaging.simp.SimpMessagingTemplate;
-import org.springframework.stereotype.Controller;
 import org.springframework.web.bind.annotation.*;
+import java.util.List;
 
 @RestController
 @RequestMapping("message")
@@ -31,12 +23,11 @@ import org.springframework.web.bind.annotation.*;
 public class MessageController {
 
     private final MessageService messageService;
+    private final int pageSize = 10;
 
-    //채팅
     @MessageMapping("chat/message")
-    public ResponseEntity<?> message(MessageDto.MessagePostDto messagePostDto) {
-        log.info("pub/chat/message");
-        return ResponseEntity.ok().body(messageService.createMessage(messagePostDto));
+    public void sendMessage(MessageDto.MessagePostDto messagePostDto) {
+        messageService.insertMessage(messagePostDto);
     }
 
     @GetMapping("/{roomId}")
@@ -46,34 +37,10 @@ public class MessageController {
             @ApiResponse(responseCode = "400", description = "BAD REQUEST !!"),
             @ApiResponse(responseCode = "404", description = "NOT FOUND !!"),
             @ApiResponse(responseCode = "500", description = "서버에서 에러가 발생하였습니다.")})
-    public Result getMessages(@RequestParam(defaultValue = "0") Integer page,
-                              @RequestParam(defaultValue = "10") Integer size,
-                              @PathVariable Long roomId) {
-        Pageable pageable = PageRequest.of(page, size, Sort.by("id").descending());
-        Page<MessageDto.MessageResponseDto> messages = messageService.getMessages(pageable, roomId);
-        return Result.createPage(messages);
+    public List<MessageDto.MessageResponseDto> getMessages(@RequestParam(defaultValue = "0") Integer page,
+                                                           @PathVariable Long roomId) {
+        Pageable pageable = PageRequest.of(page, pageSize, Sort.by("id").descending());
+        List<MessageDto.MessageResponseDto> messages = messageService.getMessages(pageable, roomId);
+        return messages;
     }
-
-    @Operation(summary = "/pub/chat/message <- 이 url에 messagePostDto form으로 json 데이터 보내주면 OK")
-    @ApiResponses({@ApiResponse(responseCode = "200" ,description = "message 정보가 정상적으로 나감",
-            content = @Content(schema = @Schema(implementation = MessageDto.MessageResponseDto.class))),
-            @ApiResponse(responseCode = "400", description = "BAD REQUEST !!"),
-            @ApiResponse(responseCode = "404", description = "NOT FOUND !!"),
-            @ApiResponse(responseCode = "500", description = "서버에서 에러가 발생하였습니다.")})
-    @GetMapping("/test1")
-    public void test1(MessageDto.MessagePostDto messagePostDto) {
-        log.info("Test 입니다.");
-    }
-
-    @Operation(summary = "/sub/chat/room/{id} <- 구독 url")
-    @ApiResponses({@ApiResponse(responseCode = "200" ,description = "message 정보가 정상적으로 나감",
-            content = @Content(schema = @Schema(implementation = MessageDto.MessageResponseDto.class))),
-            @ApiResponse(responseCode = "400", description = "BAD REQUEST !!"),
-            @ApiResponse(responseCode = "404", description = "NOT FOUND !!"),
-            @ApiResponse(responseCode = "500", description = "서버에서 에러가 발생하였습니다.")})
-    @GetMapping("/test2")
-    public void test2(MessageDto.MessagePostDto messagePostDto) {
-        log.info("Test 입니다.");
-    }
-
 }

--- a/src/main/java/com/capstone/ai_painter_backen/controller/Message/NotificationController.java
+++ b/src/main/java/com/capstone/ai_painter_backen/controller/Message/NotificationController.java
@@ -31,8 +31,8 @@ public class NotificationController {
     @ApiResponse(responseCode = "500", description = "Internal Server Error")
     @ResponseStatus(HttpStatus.OK)
     @PostMapping
-    public List<NotificationDto.NotificationResponseDto> getNotifications(@RequestParam Long userId) {
-        return notificationService.getNotificationsByUserId(userId);
+    public void getNotifications(@RequestParam Long userId) {
+        //return notificationService.getNotificationsByUserId(userId);
     }
 
     @Operation(summary = "Notification 삭제 api", description = "userId 해당 유저 모든 알림 제거")

--- a/src/main/java/com/capstone/ai_painter_backen/controller/Message/RoomController.java
+++ b/src/main/java/com/capstone/ai_painter_backen/controller/Message/RoomController.java
@@ -44,16 +44,20 @@ public class RoomController {
         return ResponseEntity.ok().body("deleted RoomId:"+deleteDto.getRoomId());
     }
 
+    /**
+     * roomId로 조회는 필요 없을 듯
+     * userId로 roomId 다 가져오고 이 roomId로 채팅 가져오고 채팅하고 다 할 수 있음.
+     */
 
-    @Operation(summary = "RoomId로 Room 조회 api", description = "roomId로 Room 조회")
-    @ApiResponse(responseCode = "200", description = "OK",
-            content = @Content(schema = @Schema(implementation = RoomDto.RoomResponseDto.class)))
-    @ApiResponse(responseCode = "400", description = "Client Error")
-    @ApiResponse(responseCode = "500", description = "Internal Server Error")
-    @GetMapping
-    public ResponseEntity<?> getRoom(@RequestParam Long roomId){
-        return ResponseEntity.ok().body(roomService.getRoom(roomId));
-    }
+//    @Operation(summary = "RoomId로 Room 조회 api", description = "roomId로 Room 조회")
+//    @ApiResponse(responseCode = "200", description = "OK",
+//            content = @Content(schema = @Schema(implementation = RoomDto.RoomResponseDto.class)))
+//    @ApiResponse(responseCode = "400", description = "Client Error")
+//    @ApiResponse(responseCode = "500", description = "Internal Server Error")
+//    @GetMapping
+//    public ResponseEntity<?> getRoom(@RequestParam Long roomId){
+//        return ResponseEntity.ok().body(roomService.getRoom(roomId));
+//    }
 
     @Operation(summary = "Room 조회 api", description = "userId로 Room 조회")
     @ApiResponse(responseCode = "200", description = "OK",

--- a/src/main/java/com/capstone/ai_painter_backen/domain/message/MessageEntity.java
+++ b/src/main/java/com/capstone/ai_painter_backen/domain/message/MessageEntity.java
@@ -5,13 +5,16 @@ import com.capstone.ai_painter_backen.domain.UserEntity;
 import jakarta.persistence.*;
 import jakarta.websocket.server.ServerEndpoint;
 import lombok.*;
+import org.springframework.data.annotation.LastModifiedDate;
+
+import java.util.Date;
 
 @Entity
 @Getter
 @Builder
 @AllArgsConstructor
 @NoArgsConstructor
-public class MessageEntity extends BaseEntity {
+public class MessageEntity{
 
     @Id @GeneratedValue(strategy = GenerationType.IDENTITY)
     private Long id;
@@ -25,6 +28,8 @@ public class MessageEntity extends BaseEntity {
     @OneToOne(fetch = FetchType.LAZY)
     @JoinColumn(name = "chat_user_id")
     private UserEntity chatUserEntity;
+
+    private Date registeredTime;
 
     //연관관계 편의 메서드
     public void addRoomEntity(RoomEntity roomEntity) {

--- a/src/main/java/com/capstone/ai_painter_backen/dto/Message/MessageDto.java
+++ b/src/main/java/com/capstone/ai_painter_backen/dto/Message/MessageDto.java
@@ -1,11 +1,6 @@
 package com.capstone.ai_painter_backen.dto.Message;
 
 import com.capstone.ai_painter_backen.constant.MessageType;
-import com.capstone.ai_painter_backen.domain.UserEntity;
-import com.capstone.ai_painter_backen.domain.message.RoomEntity;
-import com.capstone.ai_painter_backen.dto.Message.RoomDto.RoomResponseDto;
-import com.capstone.ai_painter_backen.dto.UserDto;
-import com.capstone.ai_painter_backen.dto.UserDto.UserResponseDto;
 import io.swagger.v3.oas.annotations.media.Schema;
 import lombok.*;
 
@@ -23,8 +18,6 @@ public class MessageDto {
         @Schema
         private String content;
         @Schema
-        private String writer;
-        @Schema
         private Long roomEntityId;
         @Schema
         private Long chatUserEntityId;
@@ -38,15 +31,13 @@ public class MessageDto {
     @Builder
     public static class MessageResponseDto {
         @Schema
-        private Long messageId;
-        @Schema
         private String content;
         @Schema
-        private Long roomId;
-        @Schema
-        private Long chatUserId;
+        private String writer;
         @Schema
         private String createdAt;
+        @Schema
+        private String profileImage;
     }
 
     @Schema
@@ -55,12 +46,9 @@ public class MessageDto {
     @AllArgsConstructor
     @NoArgsConstructor
     @Builder
-    public static class MessageDeleteDto {
-        @Schema
-        private Long messageId;
+    public static class MessageCacheDto {
+        private String content;
+        private String createdAt;
+        private Long chatUserId;
     }
-
-//    메세지를 수정하지는 않을듯.
-//    public static class PatchDto {
-//    }
 }

--- a/src/main/java/com/capstone/ai_painter_backen/mapper/message/MessageMapper.java
+++ b/src/main/java/com/capstone/ai_painter_backen/mapper/message/MessageMapper.java
@@ -14,29 +14,4 @@ import java.text.SimpleDateFormat;
 
 @Mapper(componentModel = "spring")
 public interface MessageMapper {
-
-    default MessageEntity messageRequestPostDtoToMessageEntity(MessageDto.MessagePostDto postDto) {
-        if (postDto == null) {
-            return null;
-        } else {
-            return MessageEntity.builder()
-                    .content(postDto.getContent())
-                    .build();
-        }
-    }
-
-    default MessageDto.MessageResponseDto messageEntityToMessageResponseDto(MessageEntity messageEntity){
-        SimpleDateFormat format = new SimpleDateFormat("yyyy-MM-dd HH:mm:ss");
-        if (messageEntity == null) {
-            return null;
-        } else {
-            return MessageDto.MessageResponseDto.builder()
-                    .messageId(messageEntity.getId())
-                    .chatUserId(messageEntity.getChatUserEntity().getId())
-                    .content(messageEntity.getContent())
-                    .createdAt(format.format(messageEntity.getRegisteredTime()))
-                    .roomId(messageEntity.getId()).build();
-        }
-    }
-
 }

--- a/src/main/java/com/capstone/ai_painter_backen/mapper/message/NotificationMapper.java
+++ b/src/main/java/com/capstone/ai_painter_backen/mapper/message/NotificationMapper.java
@@ -9,13 +9,16 @@ import org.mapstruct.Mapper;
 @Mapper(componentModel = "spring")
 public interface NotificationMapper {
 
+    /*
     default NotificationDto.NotificationResponseDto notificationEntityToNotificationResponseDto(NotificationEntity notificationEntity) {
         return NotificationDto.NotificationResponseDto.builder()
                 .NotificationId(notificationEntity.getId())
                 .messageResponseDto(messageEntityToMessageResponseDto(notificationEntity.getMessage()))
                 .userId(notificationEntity.getUser().getId()).build();
     }
+    */
 
+    /*
     default MessageDto.MessageResponseDto messageEntityToMessageResponseDto(MessageEntity messageEntity) {
         return MessageDto.MessageResponseDto.builder()
                 .messageId(messageEntity.getId())
@@ -24,4 +27,6 @@ public interface NotificationMapper {
                 .content(messageEntity.getContent())
                 .build();
     }
+    */
+
 }

--- a/src/main/java/com/capstone/ai_painter_backen/repository/message/MessageRepository.java
+++ b/src/main/java/com/capstone/ai_painter_backen/repository/message/MessageRepository.java
@@ -1,22 +1,20 @@
 package com.capstone.ai_painter_backen.repository.message;
 
 import com.capstone.ai_painter_backen.domain.message.MessageEntity;
-import com.capstone.ai_painter_backen.domain.message.RoomEntity;
 import org.springframework.data.domain.Page;
 import org.springframework.data.domain.Pageable;
 import org.springframework.data.jpa.repository.JpaRepository;
 import org.springframework.data.jpa.repository.Query;
-import org.springframework.data.repository.query.Param;
 
 import java.util.List;
 
-public interface MessageRepository extends JpaRepository<MessageEntity,Long> {
+public interface MessageRepository extends JpaRepository<MessageEntity,Long>, MessageRepositoryCustom {
 
     @Query("select m from MessageEntity m where m.roomEntity.id = :roomId")
     List<MessageEntity> findAllByRoomId(Long roomId);
 
-    @Query(value = "select m from MessageEntity  m " +
-            "join fetch m.chatUserEntity cu join fetch m.roomEntity r where r.id = :roomId",
-            countQuery = "select count(m) from MessageEntity m join m.roomEntity r where r.id = :roomId")
-    Page<MessageEntity> findAllByRoomIdWithRoomAndUser(Long roomId, Pageable pageable);
+//    @Query(value = "select m from MessageEntity  m " +
+//            "join fetch m.chatUserEntity cu join fetch m.roomEntity r where r.id = :roomId",
+//            countQuery = "select count(m) from MessageEntity m join m.roomEntity r where r.id = :roomId")
+//    Page<MessageEntity> findAllByRoomIdWithRoomAndUser(Long roomId, Pageable pageable);
 }

--- a/src/main/java/com/capstone/ai_painter_backen/repository/message/MessageRepositoryCustom.java
+++ b/src/main/java/com/capstone/ai_painter_backen/repository/message/MessageRepositoryCustom.java
@@ -1,0 +1,9 @@
+package com.capstone.ai_painter_backen.repository.message;
+
+import com.capstone.ai_painter_backen.domain.message.MessageEntity;
+import org.springframework.data.domain.Pageable;
+import java.util.List;
+
+public interface MessageRepositoryCustom {
+    List<MessageEntity> findByRoomIdReverse(Long roomId, Pageable pageable);
+}

--- a/src/main/java/com/capstone/ai_painter_backen/repository/message/MessageRepositoryImpl.java
+++ b/src/main/java/com/capstone/ai_painter_backen/repository/message/MessageRepositoryImpl.java
@@ -1,0 +1,30 @@
+package com.capstone.ai_painter_backen.repository.message;
+
+import com.capstone.ai_painter_backen.domain.message.MessageEntity;
+import com.querydsl.jpa.impl.JPAQueryFactory;
+import lombok.RequiredArgsConstructor;
+import org.springframework.data.domain.Pageable;
+import org.springframework.stereotype.Repository;
+
+import java.util.List;
+
+import static com.capstone.ai_painter_backen.domain.message.QMessageEntity.messageEntity;
+
+@RequiredArgsConstructor
+@Repository
+public class MessageRepositoryImpl implements MessageRepositoryCustom{
+
+    private final JPAQueryFactory jpaQueryFactory;
+
+    @Override
+    public List<MessageEntity> findByRoomIdReverse(Long roomId, Pageable pageable) {
+        return jpaQueryFactory
+                .selectFrom(messageEntity)
+                .innerJoin(messageEntity.chatUserEntity).fetchJoin()
+                .where(messageEntity.roomEntity.id.eq(roomId))
+                .offset(pageable.getOffset())
+                .limit(pageable.getPageSize())
+                .orderBy(messageEntity.id.desc())
+                .fetch();
+    }
+}

--- a/src/main/java/com/capstone/ai_painter_backen/repository/message/RoomRepository.java
+++ b/src/main/java/com/capstone/ai_painter_backen/repository/message/RoomRepository.java
@@ -9,7 +9,7 @@ import org.springframework.data.repository.query.Param;
 import java.util.List;
 import java.util.Optional;
 
-public interface RoomRepository extends JpaRepository<RoomEntity, Long> {
+public interface RoomRepository extends JpaRepository<RoomEntity, Long>, RoomRepositoryCustom {
     List<RoomEntity> findAllByOwnerOrVisitor(UserEntity owner, UserEntity visitor);
 
     @Query("select r from RoomEntity r where (r.visitor.id = :userId or r.owner.id = :userId) and r.id = :roomId")

--- a/src/main/java/com/capstone/ai_painter_backen/repository/message/RoomRepositoryCustom.java
+++ b/src/main/java/com/capstone/ai_painter_backen/repository/message/RoomRepositoryCustom.java
@@ -1,0 +1,9 @@
+package com.capstone.ai_painter_backen.repository.message;
+
+import com.capstone.ai_painter_backen.domain.message.RoomEntity;
+
+import java.util.Optional;
+
+public interface RoomRepositoryCustom {
+    Optional<RoomEntity> findByIdWithUsers(Long roomId);
+}

--- a/src/main/java/com/capstone/ai_painter_backen/repository/message/RoomRepositoryImpl.java
+++ b/src/main/java/com/capstone/ai_painter_backen/repository/message/RoomRepositoryImpl.java
@@ -1,0 +1,26 @@
+package com.capstone.ai_painter_backen.repository.message;
+
+import com.capstone.ai_painter_backen.domain.message.RoomEntity;
+import com.querydsl.jpa.impl.JPAQueryFactory;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Repository;
+import java.util.Optional;
+
+import static com.capstone.ai_painter_backen.domain.message.QRoomEntity.roomEntity;
+
+@RequiredArgsConstructor
+@Repository
+public class RoomRepositoryImpl implements RoomRepositoryCustom {
+
+    private final JPAQueryFactory jpaQueryFactory;
+
+    @Override
+    public Optional<RoomEntity> findByIdWithUsers(Long roomId) {
+        return Optional.ofNullable(jpaQueryFactory
+                .selectFrom(roomEntity)
+                .innerJoin(roomEntity.owner).fetchJoin()
+                .innerJoin(roomEntity.visitor).fetchJoin()
+                .where(roomEntity.id.eq(roomId))
+                .fetchOne());
+    }
+}

--- a/src/main/java/com/capstone/ai_painter_backen/service/Message/MessageService.java
+++ b/src/main/java/com/capstone/ai_painter_backen/service/Message/MessageService.java
@@ -6,25 +6,25 @@ import com.capstone.ai_painter_backen.domain.UserEntity;
 import com.capstone.ai_painter_backen.domain.message.MessageEntity;
 import com.capstone.ai_painter_backen.domain.message.RoomEntity;
 import com.capstone.ai_painter_backen.dto.Message.MessageDto;
-import com.capstone.ai_painter_backen.dto.Message.NotificationDto;
 import com.capstone.ai_painter_backen.exception.BusinessLogicException;
 import com.capstone.ai_painter_backen.exception.ExceptionCode;
-import com.capstone.ai_painter_backen.mapper.message.MessageMapper;
 import com.capstone.ai_painter_backen.repository.message.MessageRepository;
 import com.capstone.ai_painter_backen.repository.message.RoomRepository;
 import com.capstone.ai_painter_backen.repository.UserRepository;
+import com.capstone.ai_painter_backen.service.redis.RedisUtil;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
-import org.hibernate.usertype.BaseUserTypeSupport;
-import org.springframework.data.domain.Page;
-import org.springframework.data.domain.PageImpl;
+import org.springframework.data.domain.PageRequest;
 import org.springframework.data.domain.Pageable;
 import org.springframework.messaging.simp.SimpMessagingTemplate;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
-import java.util.List;
-import java.util.Optional;
+import java.text.ParseException;
+import java.text.SimpleDateFormat;
+import java.time.LocalDateTime;
+import java.time.format.DateTimeFormatter;
+import java.util.*;
 import java.util.stream.Collectors;
 
 @Service
@@ -32,60 +32,184 @@ import java.util.stream.Collectors;
 @RequiredArgsConstructor
 @Transactional(readOnly = true)
 public class MessageService {
-
     private final MessageRepository messageRepository;
     private final RoomRepository roomRepository;
     private final UserRepository userRepository;
-    private final MessageMapper messageMapper;
     private final SimpMessagingTemplate simpMessagingTemplate;
-    //어차피 단방향 의존이라 Service로 받았음.
-    private final NotificationService notificationService;
+    private final RedisUtil redisUtil;
+    private final SimpleDateFormat sdFormat = new SimpleDateFormat("yyyy/MM/dd HH:mm:ss");
+    private final SimpleDateFormat sdFormatToString = new SimpleDateFormat("yyyy-mm-dd HH:mm:ss");
+
+    private final int maximumQueueSize = 10; // 30
+    private final int commitSize = 5; // 20
+    private final int pageSize = 8; // 10
 
 
     @Transactional
-    public MessageDto.MessageResponseDto createMessage(MessageDto.MessagePostDto postDto){
+    public void insertMessage(MessageDto.MessagePostDto messagePostDto) {
+        //룸이 있는지 체크
+        roomRepository.findById(messagePostDto.getRoomEntityId()).orElseThrow(
+                () -> new BusinessLogicException(ExceptionCode.ROOM_NOT_FOUND));
 
-        UserEntity userEntity = userRepository.findById(postDto.getChatUserEntityId()).orElseThrow(
-                () -> new BusinessLogicException(ExceptionCode.MEMBER_NOT_FOUND));
+        MessageDto.MessageCacheDto messageCacheDto = MessageDto.MessageCacheDto.builder()
+                .content(messagePostDto.getContent())
+                .chatUserId(messagePostDto.getChatUserEntityId())
+                .createdAt(LocalDateTime.now().format(DateTimeFormatter.ofPattern("yyyy-MM-dd HH:mm:ss")))
+                .build();
 
-        RoomEntity roomEntity = roomRepository.findRoomByUserIdAndRoomId(
-                postDto.getChatUserEntityId(), postDto.getRoomEntityId()).orElseThrow(
-                () -> new BusinessLogicException(ExceptionCode.MEMBER_NOT_AT_ROOM));
-
-        postDto.setWriter(userEntity.getUserRealName());
-
-        if (postDto.getType() == MessageType.ENTER) {
-            postDto.setContent(postDto.getWriter() + "님이 입장했습니다.");
+        //최초 입장 시 입장 메시지 처리
+        if (messagePostDto.getType() == MessageType.ENTER) {
+            UserEntity chatUser = userRepository.findById(messagePostDto.getChatUserEntityId()).orElseThrow(
+                    () -> new BusinessLogicException(ExceptionCode.MEMBER_NOT_FOUND));
+            messageCacheDto.setContent(chatUser.getUserRealName() + "님이 입장했습니다.");
         }
 
-        MessageEntity messageEntity = messageMapper.messageRequestPostDtoToMessageEntity(postDto);
+        if (!redisUtil.containsKey(messagePostDto.getRoomEntityId())) {
+            Queue<MessageDto.MessageCacheDto> messageQueue = new LinkedList<>();
+            messageQueue.add(messageCacheDto);
 
-        simpMessagingTemplate.convertAndSend("/sub/chat/room/" + Long.toString(postDto.getRoomEntityId()), postDto);
+            redisUtil.put(messagePostDto.getRoomEntityId(), messageQueue);
+            redisUtil.putDummy(messagePostDto.getRoomEntityId());
+        } else {
+            Queue<MessageDto.MessageCacheDto> messageQueue = redisUtil.get(messagePostDto.getRoomEntityId());
+            messageQueue.add(messageCacheDto);
 
-        messageEntity.addRoomEntity(roomEntity);
-        messageEntity.setChatUserEntity(userEntity);
+            if (messageQueue.size() > maximumQueueSize) {
+                Queue<MessageDto.MessageCacheDto> queue = new LinkedList<>();
+                for (int i = 0; i < commitSize; i++) {
+                    queue.add(messageQueue.poll());
+                }
+                commitMessage(queue, messagePostDto.getRoomEntityId());
+            }
 
-        MessageEntity savedMessage = messageRepository.save(messageEntity);
+            redisUtil.put(messagePostDto.getRoomEntityId(), messageQueue);
+            redisUtil.putDummy(messagePostDto.getRoomEntityId());
+        }
 
-        NotificationDto.NotificationPostDto notificationPostDto = NotificationDto.NotificationPostDto.builder()
-                .chatUserEntityId(postDto.getChatUserEntityId())
-                .roodEntityId(postDto.getRoomEntityId())
-                .content(postDto.getContent())
-                .messageEntityId(savedMessage.getId()).build();
+        log.info("CacheSize : {}", redisUtil.get(messagePostDto.getRoomEntityId()).size());
 
-        notificationService.createNotification(notificationPostDto);
-
-        return messageMapper.messageEntityToMessageResponseDto(savedMessage);
+        simpMessagingTemplate.convertAndSend("/sub/chat/room/" + messagePostDto.getRoomEntityId(), messagePostDto);
     }
 
-    public Page<MessageDto.MessageResponseDto> getMessages(Pageable pageable, Long roomId) {
-        RoomEntity roomEntity = roomRepository.findById(roomId).orElseThrow(
-                () -> new BusinessLogicException(ExceptionCode.ROOM_NOT_FOUND));
-        Page<MessageEntity> messageEntities = messageRepository.findAllByRoomIdWithRoomAndUser(roomId, pageable);
-        List<MessageDto.MessageResponseDto> messageResponseDtos = messageEntities.stream()
-                .map(messageMapper::messageEntityToMessageResponseDto)
-                .collect(Collectors.toList());
+    @Transactional
+    public void commitMessage(Queue<MessageDto.MessageCacheDto> queue, Long roomId) {
+        for (int i = 0; i < commitSize; i++) {
+            MessageDto.MessageCacheDto messageCacheDto = queue.poll();
+            UserEntity chatUser = userRepository.findById(messageCacheDto.getChatUserId()).orElseThrow(
+                    () -> new BusinessLogicException(ExceptionCode.MEMBER_NOT_FOUND));
 
-        return new PageImpl<>(messageResponseDtos, messageEntities.getPageable(), messageEntities.getNumber());
+            RoomEntity chatRoom = roomRepository.findById(roomId).orElseThrow(
+                    () -> new BusinessLogicException(ExceptionCode.ROOM_NOT_FOUND));
+
+            try {
+                MessageEntity chatMessage = MessageEntity.builder()
+                        .chatUserEntity(chatUser)
+                        .roomEntity(chatRoom)
+                        .content(messageCacheDto.getContent())
+                        .registeredTime(sdFormatToString.parse(messageCacheDto.getCreatedAt()))
+                        .build();
+
+                messageRepository.save(chatMessage);
+            } catch (ParseException e) {
+                log.info("parse error");
+            }
+        }
+    }
+
+    public List<MessageDto.MessageResponseDto> getMessages(Pageable pageable, Long roomId) {
+        //cache hit 경우, user 같이 안가져오면 한번 더 조회해야 함.
+        //fetchJoin 으로 한 번에 가져오도록 변경
+        RoomEntity roomEntity = roomRepository.findByIdWithUsers(roomId).orElseThrow(
+                () -> new BusinessLogicException(ExceptionCode.ROOM_NOT_FOUND));
+
+        List<MessageDto.MessageResponseDto> messageResponses = new ArrayList<>();
+
+        // Cache miss
+        if (!redisUtil.containsKey(roomId)) {
+            List<MessageEntity> messageEntities = messageRepository.findByRoomIdReverse(roomId, pageable);
+            //DB 에도 없는 경우 (아직 채팅을 한 번도 안친 경우) -> 빈 List 반환
+            if (messageEntities.isEmpty()) return messageResponses;
+
+            //Cache 에 저장될 값
+            List<MessageDto.MessageCacheDto> messageCacheDtos = messageEntities.stream()
+                    .map(m -> new MessageDto.MessageCacheDto(m.getContent(),
+                            sdFormat.format(m.getRegisteredTime()).toString(),
+                            m.getChatUserEntity().getId()))
+                    .collect(Collectors.toList());
+
+            //Response 로 보낼 값
+            List<MessageDto.MessageResponseDto> messageResponseDtos = messageEntities.stream()
+                    .map(m -> new MessageDto.MessageResponseDto(m.getContent(),
+                            m.getChatUserEntity().getUserRealName(),
+                            sdFormat.format(m.getRegisteredTime()).toString(),
+                            m.getChatUserEntity().getProfileImage()))
+                    .collect(Collectors.toList());
+
+
+            //Cache 및 Response 값 세팅
+            Queue<MessageDto.MessageCacheDto> queue = new LinkedList<>(messageCacheDtos);
+            redisUtil.put(roomId, queue);
+            messageResponses = messageResponseDtos;
+        } else { // Cache hit
+            //이미지, 이름 조회를 각 메시지마다 하지 않고 한 번만 조회하도록 최적화
+            String ownerName = roomEntity.getOwner().getUserRealName();
+            String ownerImage = roomEntity.getOwner().getProfileImage();
+            String visitorName = roomEntity.getVisitor().getUserRealName();
+            String visitorImage = roomEntity.getVisitor().getProfileImage();
+
+            LinkedList<MessageDto.MessageCacheDto> messageCacheDtos = redisUtil.get(roomId);
+            log.info("chache 에 있는 메시지 개수 : {}", messageCacheDtos.size());
+
+            //시작 조회 위치
+            int start = pageable.getPageNumber() * pageSize;
+
+            //페이지 오버
+            if (start > messageCacheDtos.size() - 1) {
+                return messageResponses;
+            } else {
+                for (int i = start; i < start + pageSize; i++) {
+                    //Cache 초과
+                    if (i > messageCacheDtos.size() - 1) {
+                        if (!messageResponses.isEmpty()) {
+                            Collections.reverse(messageResponses);
+                        }
+                        //남은 pageSize 만큼 DB 에서 가져오기
+                        PageRequest pageRequest = PageRequest.of(0, pageSize - (i - start));
+                        log.info("pageSize - (i - start) : {}", pageSize - (i - start));
+                        List<MessageEntity> messageEntities = messageRepository.findByRoomIdReverse(roomId, pageRequest);
+                        for (MessageEntity messageEntity : messageEntities) {
+                            messageResponses.add(new MessageDto.MessageResponseDto(messageEntity.getContent(),
+                                    messageEntity.getChatUserEntity().getUserRealName(),
+                                    sdFormat.format(messageEntity.getRegisteredTime()),
+                                    messageEntity.getChatUserEntity().getProfileImage()));
+                        }
+
+                        break;
+                    }
+
+                    MessageDto.MessageCacheDto messageCacheDto = messageCacheDtos.get(i);
+
+                    MessageDto.MessageResponseDto messageResponseDto = null;
+                    if (messageCacheDto.getChatUserId() == roomEntity.getOwner().getId()) {
+                        messageResponseDto = getMessageResponse(ownerName, ownerImage, messageCacheDto);
+                    } else {
+                        messageResponseDto = getMessageResponse(visitorName, visitorImage, messageCacheDto);
+                    }
+
+                    log.info("Cache에 있는 값 사용");
+                    messageResponses.add(messageResponseDto);
+                }
+            }
+        }
+        return messageResponses;
+    }
+
+    private MessageDto.MessageResponseDto getMessageResponse(String writer, String image, MessageDto.MessageCacheDto messageCacheDto) {
+        return MessageDto.MessageResponseDto.builder()
+                .content(messageCacheDto.getContent())
+                .createdAt(messageCacheDto.getCreatedAt())
+                .profileImage(image)
+                .writer(writer)
+                .build();
     }
 }

--- a/src/main/java/com/capstone/ai_painter_backen/service/Message/NotificationService.java
+++ b/src/main/java/com/capstone/ai_painter_backen/service/Message/NotificationService.java
@@ -58,7 +58,7 @@ public class NotificationService {
     }
 
     @Transactional
-    public List<NotificationDto.NotificationResponseDto> getNotificationsByUserId(Long userId) {
+    public void getNotificationsByUserId(Long userId) {
         UserEntity savedUserEntity = userRepository.findById(userId).orElseThrow(
                 () -> new BusinessLogicException(ExceptionCode.MEMBER_NOT_FOUND));
 
@@ -69,8 +69,8 @@ public class NotificationService {
             notificationEntity.check();
         }
 
-        return notificationEntities.stream()
-                .map(notificationMapper::notificationEntityToNotificationResponseDto).collect(Collectors.toList());
+        //return notificationEntities.stream()
+        //        .map(notificationMapper::notificationEntityToNotificationResponseDto).collect(Collectors.toList());
     }
 
     @Transactional

--- a/src/main/java/com/capstone/ai_painter_backen/service/redis/ExpirationListener.java
+++ b/src/main/java/com/capstone/ai_painter_backen/service/redis/ExpirationListener.java
@@ -1,0 +1,33 @@
+package com.capstone.ai_painter_backen.service.redis;
+
+import com.capstone.ai_painter_backen.dto.Message.MessageDto;
+import com.capstone.ai_painter_backen.service.Message.MessageService;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.data.redis.connection.Message;
+import org.springframework.data.redis.connection.MessageListener;
+import org.springframework.stereotype.Component;
+
+import java.util.LinkedList;
+import java.util.Queue;
+
+@RequiredArgsConstructor
+@Component
+@Slf4j
+public class ExpirationListener implements MessageListener {
+
+    private final RedisUtil redisUtil;
+    private final MessageService messageService;
+
+    @Override
+    public void onMessage(Message message, byte[] pattern) {
+        log.info("onMessage Key expiration {}", message.toString());
+        Long roomId = Long.valueOf(message.toString().substring(4));
+        LinkedList<MessageDto.MessageCacheDto> messageCacheDtos = redisUtil.get(roomId);
+        Queue<MessageDto.MessageCacheDto> messageQueue = new LinkedList<>(messageCacheDtos);
+
+        messageService.commitMessage(messageQueue, roomId);
+
+        redisUtil.deleteKey(roomId);
+    }
+}

--- a/src/main/java/com/capstone/ai_painter_backen/service/redis/RedisUtil.java
+++ b/src/main/java/com/capstone/ai_painter_backen/service/redis/RedisUtil.java
@@ -1,0 +1,50 @@
+package com.capstone.ai_painter_backen.service.redis;
+
+import com.capstone.ai_painter_backen.dto.Message.MessageDto;
+import lombok.RequiredArgsConstructor;
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.data.redis.core.RedisTemplate;
+import org.springframework.stereotype.Component;
+
+import java.util.LinkedList;
+import java.util.Objects;
+import java.util.Queue;
+import java.util.concurrent.TimeUnit;
+
+@Component
+@RequiredArgsConstructor
+public class RedisUtil {
+    private final RedisTemplate<String, LinkedList<MessageDto.MessageCacheDto>> redisTemplate;
+
+    @Value("${spring.redis.expire}")
+    private int expireTime;
+
+    public void put(Long roomId, Queue<MessageDto.MessageCacheDto> messageQueue) {
+        redisTemplate.opsForValue().set(roomId.toString(), new LinkedList<>(messageQueue));
+    }
+
+    public void putDummy(Long roomId) {
+        redisTemplate.opsForValue().set("room" + roomId.toString(), new LinkedList<>());
+        redisTemplate.expire("room" + roomId.toString(), expireTime, TimeUnit.MINUTES);
+    }
+
+    public boolean containsKey(Long roomId) {
+        return Boolean.TRUE.equals(redisTemplate.hasKey(roomId.toString()));
+    }
+
+    public LinkedList<MessageDto.MessageCacheDto> get(Long roomId) {
+        return redisTemplate.opsForValue().get(roomId.toString());
+    }
+
+    public Queue<MessageDto.MessageCacheDto> value() {
+        return get(Long.valueOf(Objects.requireNonNull(redisTemplate.randomKey())));
+    }
+
+    public void deleteKey(Long roomId) {
+        redisTemplate.delete(roomId.toString());
+    }
+
+    public void deleteAll() {
+        redisTemplate.discard();
+    }
+}

--- a/src/test/java/com/capstone/ai_painter_backen/repository/message/MessageRepositoryImplTest.java
+++ b/src/test/java/com/capstone/ai_painter_backen/repository/message/MessageRepositoryImplTest.java
@@ -1,0 +1,72 @@
+package com.capstone.ai_painter_backen.repository.message;
+
+import com.capstone.ai_painter_backen.domain.UserEntity;
+import com.capstone.ai_painter_backen.domain.message.MessageEntity;
+import com.capstone.ai_painter_backen.domain.message.RoomEntity;
+import com.capstone.ai_painter_backen.repository.UserRepository;
+import org.assertj.core.api.Assertions;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.data.domain.PageRequest;
+import org.springframework.transaction.annotation.Transactional;
+
+import java.util.List;
+import java.util.UUID;
+
+import static org.junit.jupiter.api.Assertions.*;
+
+@SpringBootTest
+@Transactional
+class MessageRepositoryImplTest {
+
+    @Autowired
+    private UserRepository userRepository;
+
+    @Autowired
+    private MessageRepository messageRepository;
+
+    @Autowired
+    private RoomRepository roomRepository;
+
+    @Test
+    void findByRoomIdReverse() {
+        //given
+        UserEntity owner = UserEntity.createUserEssential(UUID.randomUUID().toString(), "qwer", UUID.randomUUID().toString());
+        UserEntity visitor = UserEntity.createUserEssential(UUID.randomUUID().toString(), "asdf", UUID.randomUUID().toString());
+        userRepository.save(owner);
+        userRepository.save(visitor);
+
+        RoomEntity roomEntity = getRoom(owner, visitor);
+        roomRepository.save(roomEntity);
+
+        for (int i = 0; i < 20; i++) {
+            MessageEntity messageEntity = MessageEntity.builder()
+                    .roomEntity(roomEntity)
+                    .chatUserEntity(owner)
+                    .content("hello " + i)
+                    .build();
+            messageRepository.save(messageEntity);
+        }
+
+        //when
+        PageRequest pageRequest1 = PageRequest.of(0, 10);
+        PageRequest pageRequest2 = PageRequest.of(1, 8);
+        List<MessageEntity> findMessageEntities1 = messageRepository.findByRoomIdReverse(roomEntity.getId(), pageRequest1);
+        List<MessageEntity> findMessageEntities2 = messageRepository.findByRoomIdReverse(roomEntity.getId(), pageRequest2);
+
+        //then
+        Assertions.assertThat(findMessageEntities1.size()).isEqualTo(10);
+        Assertions.assertThat(findMessageEntities1.get(0).getId()).isEqualTo(20);
+
+        Assertions.assertThat(findMessageEntities2.size()).isEqualTo(8);
+        Assertions.assertThat(findMessageEntities2.get(0).getId()).isEqualTo(12);
+    }
+
+    private RoomEntity getRoom(UserEntity owner, UserEntity visitor) {
+        return RoomEntity.builder()
+                .owner(owner)
+                .visitor(visitor)
+                .build();
+    }
+}

--- a/src/test/java/com/capstone/ai_painter_backen/repository/message/RoomRepositoryImplTest.java
+++ b/src/test/java/com/capstone/ai_painter_backen/repository/message/RoomRepositoryImplTest.java
@@ -1,0 +1,53 @@
+package com.capstone.ai_painter_backen.repository.message;
+
+import com.capstone.ai_painter_backen.domain.UserEntity;
+import com.capstone.ai_painter_backen.domain.message.RoomEntity;
+import com.capstone.ai_painter_backen.repository.UserRepository;
+import org.assertj.core.api.Assertions;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.transaction.annotation.Transactional;
+
+import java.util.ArrayList;
+import java.util.Optional;
+import java.util.UUID;
+
+import static org.junit.jupiter.api.Assertions.*;
+
+
+@SpringBootTest
+@Transactional
+class RoomRepositoryImplTest {
+
+    @Autowired
+    private UserRepository userRepository;
+
+    @Autowired
+    private RoomRepository roomRepository;
+
+    @Test
+    void findByIdWithUsers() {
+        //given
+        UserEntity owner = UserEntity.createUserEssential(UUID.randomUUID().toString(), "qwer", UUID.randomUUID().toString());
+        UserEntity visitor = UserEntity.createUserEssential(UUID.randomUUID().toString(), "asdf", UUID.randomUUID().toString());
+        userRepository.save(owner);
+        userRepository.save(visitor);
+
+        RoomEntity roomEntity = RoomEntity.builder()
+                .owner(owner)
+                .visitor(visitor)
+                .messageEntities(new ArrayList<>())
+                .build();
+        roomRepository.save(roomEntity);
+
+        //when
+        RoomEntity findRoomEntity = roomRepository.findByIdWithUsers(roomEntity.getId()).get();
+
+        //then
+        Assertions.assertThat(findRoomEntity.getId()).isEqualTo(roomEntity.getId());
+        Assertions.assertThat(findRoomEntity.getOwner()).isEqualTo(owner);
+        Assertions.assertThat(findRoomEntity.getVisitor()).isEqualTo(visitor);
+    }
+}


### PR DESCRIPTION
## [refactor]
* 채팅 저장
  * Write Back 패턴 적용
  * redis에 일정 개수의 채팅이 쌓일 때까지 기다렸다가 한 번에 DB에 넣도록 구현
* 채팅 읽기
  * Look Aside 패턴 적용
  * DB에서 조회하기 전에 redis에서 먼저 조회함으로써 성능을 높임.
* querydsl 적용
  * JPQL -> querydsl

## TODO
* 다른 브랜치 모두 merge 하면 stompHandler 구현해서 jwt 인증 적용하기
  * 이에 따라 dto 달라질 수 있음.
* 테스트 코드 작성하기

## 날짜
9/20일 18
